### PR TITLE
Load chatbot password from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# BBoyer23.github.io
+
+This repository contains the static files for Benjamin Boyer's personal site.
+
+## Configuration
+
+The AI chatbot on the **Fun Zone** page is password protected.  The password is
+loaded from `js/config.js`.  Edit that file before deploying to set your own
+secret:
+
+```javascript
+window.APP_CONFIG = {
+    CHATBOT_PASSWORD: "YourSecretPassword"
+};
+```
+
+Make sure `config.js` is included on every page (it is already referenced by the
+HTML files in this repo).  The scripts will read `window.APP_CONFIG.CHATBOT_PASSWORD`
+when checking the password.

--- a/fun.html
+++ b/fun.html
@@ -104,6 +104,8 @@
   <p>&copy; 2024 Benjamin Boyer. All Rights Reserved.</p>
 </footer>
 
+<!-- Config file must be loaded before other scripts -->
+<script src="js/config.js"></script>
 <!-- Single Script Reference as a Module -->
 <script type="module" src="js/script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -209,6 +209,8 @@
     <p>&copy; 2025 Benjamin Boyer. All Rights Reserved.</p>
 </footer>
 
+<!-- Config file must be loaded before other scripts -->
+<script src="js/config.js"></script>
 <!-- Single Script Reference as a Module -->
 <script type="module" src="js/script.js"></script>
 </body>

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,3 @@
+window.APP_CONFIG = {
+    CHATBOT_PASSWORD: "BBoyerAI2024"
+};

--- a/js/fun.js
+++ b/js/fun.js
@@ -81,8 +81,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const chatPasswordSubmit = document.getElementById("chat-password-submit");
     const passwordError = document.getElementById("password-error");
 
-    // Set your password here (Change for security)
-    const chatbotPassword = "BBoyerAI2024";
+    // Read the password from config.js or environment variable
+    const chatbotPassword = window.APP_CONFIG?.CHATBOT_PASSWORD || "";
 
     chatPasswordSubmit.addEventListener("click", () => {
         const enteredPassword = chatPasswordInput.value.trim();

--- a/projects.html
+++ b/projects.html
@@ -290,6 +290,7 @@
 </footer>
 
 <!-- Scripts -->
+<script src="js/config.js"></script>
 <script type="module" src="js/script.js"></script>
 <script>
     document.getElementById('load-code').addEventListener('click', () => {

--- a/resume.html
+++ b/resume.html
@@ -68,6 +68,8 @@
     <p>&copy; 2024 Benjamin Boyer. All Rights Reserved.</p>
 </footer>
 
+<!-- Config file must be loaded before other scripts -->
+<script src="js/config.js"></script>
 <!-- Single Script Reference as a Module -->
 <script type="module" src="js/script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a config file for storing the chatbot password
- load password from `window.APP_CONFIG.CHATBOT_PASSWORD`
- document how to set the password
- include the config script on all HTML pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a1c2e24ac83318515f01d1a6997dc