### PR TITLE
Add persistent chat history with clear option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ window.APP_CONFIG = {
 Make sure `config.js` is included on every page (it is already referenced by the
 HTML files in this repo).  The scripts will read `window.APP_CONFIG.CHATBOT_PASSWORD`
 when checking the password.
+
+### Fun Zone Enhancements
+
+The chatbot now keeps a chat history in your browser. Use the new **Clear** button
+to wipe the conversation or refresh the page to continue where you left off.

--- a/css/fun.css
+++ b/css/fun.css
@@ -54,6 +54,7 @@
     flex-direction: column;
     align-items: center;
     margin-top: 20px;
+    gap: 10px;
 }
 .chat-input {
     width: 80%;

--- a/fun.html
+++ b/fun.html
@@ -88,6 +88,7 @@
   <div class="chat-box">
     <input type="text" id="chat-input" class="chat-input" placeholder="Type your question..." aria-label="Your question">
     <button id="chat-submit" class="btn">Ask</button>
+    <button id="chat-clear" class="btn">Clear</button>
   </div>
   <div id="chat-output" class="chat-output"></div>
 </section>

--- a/js/fun.js
+++ b/js/fun.js
@@ -107,10 +107,17 @@ document.addEventListener("DOMContentLoaded", () => {
     // ========== AI CHATBOT ==========
     const chatInput = document.getElementById("chat-input");
     const chatSubmit = document.getElementById("chat-submit");
+    const chatClear = document.getElementById("chat-clear");
     const chatOutput = document.getElementById("chat-output");
 
     if (chatInput && chatSubmit && chatOutput) {
         console.log("✅ Chatbot elements found. Initializing chatbot.");
+
+        // Load stored history if available
+        const storedHistory = localStorage.getItem('chatHistory');
+        if (storedHistory) {
+            chatOutput.innerHTML = storedHistory;
+        }
 
         chatSubmit.addEventListener("click", async () => {
             const userMessage = chatInput.value.trim();
@@ -133,6 +140,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 console.error("[fun.js] Chatbot error:", error);
             }
 
+            localStorage.setItem('chatHistory', chatOutput.innerHTML);
             chatInput.value = "";
         });
 
@@ -142,6 +150,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 chatSubmit.click();
             }
         });
+
+        if (chatClear) {
+            chatClear.addEventListener("click", () => {
+                chatOutput.innerHTML = "";
+                localStorage.removeItem('chatHistory');
+            });
+        }
     }
 
     // ========== MINI GAME ==========


### PR DESCRIPTION
## Summary
- add a Clear button for the Fun Zone chatbot
- persist chat history between page loads using localStorage
- style spacing for the chat controls
- document the enhancement in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685a1e167bac833187e50f215680c28f